### PR TITLE
Don't subscribe until leaving the text field

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -21,7 +21,7 @@ export const QueryEditor = (props: Props) => {
             value={query.queryText}
             css=""
             autoComplete="off"
-            onChange={handleEvent('queryText')}
+            onBlur={handleEvent('queryText')}
           />
         </Field>
       )}

--- a/src/handleEvent.test.ts
+++ b/src/handleEvent.test.ts
@@ -1,11 +1,11 @@
-import { ChangeEvent } from 'react';
+import { FocusEvent } from 'react';
 import { handlerFactory } from './handleEvent';
 
 const changeEvent = {
   currentTarget: {
     value: 'test',
   },
-} as ChangeEvent<HTMLInputElement>;
+} as FocusEvent<HTMLInputElement>;
 
 describe('handlerFactory', () => {
   it('returns value from event', () => {

--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -1,10 +1,10 @@
-import { ChangeEvent } from 'react';
+import { FocusEvent } from 'react';
 import _ from 'lodash';
 
 export const handlerFactory =
   (original: object, onChange: (copy: any) => void) =>
   (path: string, format: (value: string) => string | number | boolean | null = (value) => value) =>
-  (event: ChangeEvent<HTMLInputElement>): void => {
+  (event: FocusEvent<HTMLInputElement>): void => {
     const copy = _.cloneDeep(original);
     onChange(_.set(copy, path, format(event.currentTarget.value)));
   };


### PR DESCRIPTION
When adding a new topic to an MQTT data source, for example topic "foo/bar/test",
the plugin will first subscribe to the empty topic, then while typing to f, fo, foo, foo/ ... and finally to foo/bar/test.
It will then after a few seconds unsubscribe to all the the invalid topics.
This seems unnecessary. This commit changes the behavior to only subscribe when the text field looses focus.