### PR TITLE
Handle multiple topics from the same data source

### DIFF
--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -66,3 +66,5 @@ func (c *fakeMQTTClient) Stream() chan mqtt.StreamMessage {
 func (c *fakeMQTTClient) Subscribe(_ string) {}
 
 func (c *fakeMQTTClient) Unsubscribe(_ string) {}
+
+func (c *fakeMQTTClient) Dispose() {}

--- a/pkg/plugin/message.go
+++ b/pkg/plugin/message.go
@@ -24,7 +24,7 @@ func ToFrame(topic string, messages []mqtt.Message) *data.Frame {
 	timeField := data.NewFieldFromFieldType(data.FieldTypeTime, count)
 	timeField.Name = "Time"
 	valueField := data.NewFieldFromFieldType(data.FieldTypeFloat64, count)
-	valueField.Name = "Value"
+	valueField.Name = topic
 
 	for idx, m := range messages {
 		if value, err := strconv.ParseFloat(m.Value, 64); err == nil {


### PR DESCRIPTION
1.
When subscribing to N topics from the same data source only 1/N of the updates for each topic are sent from backend to frontend. This is due to N goroutines picking messages from the same channel in a round-robin fashion and discarding any message not pertaining to the the topic that particular goroutine is serving.
The fix is for the goroutines to reinsert such messages into the channel instead of discarding them.

2.
When the message payloads are simple numeric values rather than json objects they will all be sent to frontend as a field with the literal name "Value", which makes is hard to distinguish between data for different topics.
The fix is to use the topic string instead of "Value" when receiving numeric payloads.